### PR TITLE
feat: github actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Build macOS Apple Silicon (arm64)
+        run: |
+          mkdir -p dist
+          GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/pyrpm-macos-arm64 .
+
+      - name: Build Windows (amd64)
+        run: |
+          GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/pyrpm-windows-x64.exe .
+
+      - name: Build Linux (amd64)
+        run: |
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/pyrpm-linux-x64 .
+
+      - name: Build Linux (386)
+        run: |
+          GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/pyrpm-linux-x86 .
+
+      - name: Generate Release Notes
+        id: release_notes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            echo "notes<<EOF" >> $GITHUB_OUTPUT
+            echo "## $PR_TITLE" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "$PR_BODY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "tag=v${RUN_NUMBER}-${SHA}" >> $GITHUB_OUTPUT
+            echo "title=Release from PR: $PR_TITLE" >> $GITHUB_OUTPUT
+          else
+            echo "notes<<EOF" >> $GITHUB_OUTPUT
+            echo "Manual release triggered from branch: $REF_NAME" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "tag=v${RUN_NUMBER}-${SHA}-manual" >> $GITHUB_OUTPUT
+            echo "title=Manual Release ($REF_NAME)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release_notes.outputs.tag }}
+          name: ${{ steps.release_notes.outputs.title }}
+          body: ${{ steps.release_notes.outputs.notes }}
+          files: dist/*

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ build:
 	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(APP_NAME)-windows-x64.exe .
 	@echo "Building for Linux (amd64)..."
 	GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(APP_NAME)-linux-x64 .
+	@echo "Building for Linux (386)..."
+	GOOS=linux GOARCH=386 go build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(APP_NAME)-linux-x86 .
 
 clean:
 	rm -rf $(DIST_DIR)

--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,7 @@ GOOS=windows GOARCH=amd64 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}
 echo "Building for Linux (amd64)..."
 GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}-linux-x64" .
 
+echo "Building for Linux (386)..."
+GOOS=linux GOARCH=386 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}-linux-x86" .
+
 echo "Build complete. Binaries are in the $DIST_DIR directory."


### PR DESCRIPTION
Adds a GitHub action workflow that natively creates a release. It's triggered manually (where branch selection is provided out-of-the-box by workflow dispatch) or when a PR is merged into master. The release body pulls information from the PR context dynamically to populate release notes and attaches binary distributions for the four requested OS architectures. Additionally, the standard build scripts were updated.

---
*PR created automatically by Jules for task [4328763013782448484](https://jules.google.com/task/4328763013782448484) started by @tyronechrisharris*