### PR TITLE
Add Linux ARM64 (Raspberry Pi 4) build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/gorpm-linux-x86 .
 
+      - name: Build Linux (arm64)
+        run: |
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/gorpm-linux-arm64 .
+
       - name: Generate Release Notes
         id: release_notes
         env:

--- a/build.sh
+++ b/build.sh
@@ -22,4 +22,7 @@ GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}-l
 echo "Building for Linux (386)..."
 GOOS=linux GOARCH=386 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}-linux-x86" .
 
+echo "Building for Linux (arm64)..."
+GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o "$DIST_DIR/${APP_NAME}-linux-arm64" .
+
 echo "Build complete. Binaries are in the $DIST_DIR directory."


### PR DESCRIPTION
This adds support for compiling and releasing the application for the Raspberry Pi 4, by targeting Linux ARM64 in the `release.yml` GitHub Actions workflow and the `build.sh` script.

---
*PR created automatically by Jules for task [9460652735472816792](https://jules.google.com/task/9460652735472816792) started by @tyronechrisharris*